### PR TITLE
'time hack' to prevent ERROR 33 GATEWAY IS NOT FOUND

### DIFF
--- a/netdimm/netdimm.py
+++ b/netdimm/netdimm.py
@@ -231,6 +231,11 @@ class NetDimm:
             # set time limit to 10 minutes.
             self.__set_time_limit(10)
 
+    def set_time_limit(self) -> None:
+        with self.connection():
+            # set time limit to 10 minutes.
+            self.__set_time_limit(10)
+
     def peek(self, addr: int, type: PeekPokeTypeEnum) -> int:
         with self.connection():
             return self.__host_peek(addr, type)

--- a/netdimm/netdimm.py
+++ b/netdimm/netdimm.py
@@ -231,10 +231,10 @@ class NetDimm:
             # set time limit to 10 minutes.
             self.__set_time_limit(10)
 
-    def set_time_limit(self) -> None:
+    def set_time_limit(self, limit: int) -> None:
         with self.connection():
             # set time limit to 10 minutes.
-            self.__set_time_limit(10)
+            self.__set_time_limit(limit)
 
     def peek(self, addr: int, type: PeekPokeTypeEnum) -> int:
         with self.connection():

--- a/scripts/netdimm_send.py
+++ b/scripts/netdimm_send.py
@@ -161,7 +161,7 @@ def main() -> int:
         if args.keyless_boot:
             print("keyless boot: infinite set_time_limit() loop")
             while True:
-                netdimm.set_time_limit()
+                netdimm.set_time_limit(10)
                 time.sleep(5)
     return 0
 

--- a/scripts/netdimm_send.py
+++ b/scripts/netdimm_send.py
@@ -4,6 +4,7 @@
 import argparse
 import enum
 import sys
+import time
 from arcadeutils import FileBytes, BinaryDiff
 from netboot import TargetEnum
 from netdimm import NetDimm, NetDimmVersionEnum
@@ -109,6 +110,13 @@ def main() -> int:
         help="Disable displaying the \"NOW LOADING...\" screen when sending the game",
     )
 
+    # Prevent ERROR 33 GATEWAY IS NOT FOUND due to bad, or missing PIC chip.
+    parser.add_argument(
+        '--keyless-boot',
+        action="store_true",
+        help="Enable boot without Key Chip, by using the 'time hack'",
+    )
+
     args = parser.parse_args()
 
     # If the user specifies a key (not normally done), convert it
@@ -150,6 +158,11 @@ def main() -> int:
         netdimm.reboot()
         print("ok!", file=sys.stderr)
 
+        if args.keyless_boot:
+            print("keyless boot: infinite set_time_limit() loop")
+            while True:
+                netdimm.set_time_limit()
+                time.sleep(5)
     return 0
 
 


### PR DESCRIPTION
Original triforce tools were patched to include a "time hack"
https://web.archive.org/web/20090428225712/http://debugmo.de:80/wp-content/uploads/2009/04/triforcetools.py
https://github.com/Jesuszilla/naomiselect/blob/master/naomi_boot.py#L229 
"time hack looping"

Modern replacements all seem to include this same functionality to help with bad, or missing PIC chips.
https://github.com/JanekvO/naomi_netboot_upload/blob/master/netboot_upload.c#L95 
"Entering infinite loop"

This PR adds the same functionality for people that wish to use it with a new command line option --keyless-boot that prevents the program from exiting, while instead sending a set_time_limit() packet every 5 seconds, which has been shown to be enough to keep missing, or bad PIC's from preventing a game from running more than a few minutes. 

Example usage:
```
$ ./netdimm_send --keyless-boot 192.168.1.121 ./TheTypingOfTheDead_public_ENGBETA.bin 
```