### PR TITLE
Selectively adjust timeout handling, only for darwin

### DIFF
--- a/netdimm/netdimm.py
+++ b/netdimm/netdimm.py
@@ -2,6 +2,7 @@
 # Triforce Netfirm Toolbox, put into the public domain.
 # Please attribute properly, but only if you want.
 import os
+import sys
 import socket
 import struct
 import time
@@ -285,9 +286,15 @@ class NetDimm:
         # - pre-type3 triforces jumpered to satellite mode.
         try:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.sock.settimeout(1)
-            self.sock.connect((self.ip, 10703))
-            self.sock.settimeout(10)
+            if sys.platform == 'darwin':
+                self.sock.settimeout(15)
+                self.sock.setblocking(True)
+                self.sock.connect((self.ip, 10703))
+            else:
+                self.sock.settimeout(1)
+                self.sock.connect((self.ip, 10703))
+                self.sock.settimeout(10)
+
         except Exception as e:
             raise NetDimmException("Could not connect to NetDimm") from e
 


### PR DESCRIPTION
Known issues:
[sending on OSX doesn't work](https://github.com/DragonMinded/netboot/issues/6)
[[Errno 32] Broken pipe received when trying to load game via netdimm_send](https://github.com/DragonMinded/netboot/issues/1)

Fix: 
So as not to impact Linux users as requested [here](https://github.com/DragonMinded/netboot/issues/6#issuecomment-1013585268), this PR implements a conditional change in the timeout function, only on Darwin systems. Linux users would use the original code path. 

Testing:
In order to make sure this was a workable solution the main tools were tested as follows...

Testing on macOS Monterey 12.1

```
$ python3 ./netdimm_info 192.168.1.121
Requesting...
DIMM Firmware Version: 3.17
DIMM Memory Size: 512 MB
Available Game Memory Size: 496 MB
Current Game CRC: aed35f56 (240 MB) (checking...)

$ python3 ./netdimm_send 192.168.1.121 rhytngk.bin --keyless-boot
sending...
length: 0f000000
rebooting into game...
ok!
keyless boot: infinite set_time_limit() loop

(turning off cabinet gives expected python TimeoutError: [Errno 60] Operation timed out, netdimm.netdimm.NetDimmException: Could not connect to NetDimm error stack )


$ python3 ./netdimm_ensure 192.168.1.121 rhytngk.bin (output edited to show all states possible)
managing 192.168.1.121 to ensure rhytngk.bin is always loaded
verifying game crc...
running game...
waiting for cabinet...   (several seconds after cabinet powered down)
sending (11%)...         (cabinet powered back on)
waiting for cabinet...   (cabinet powered down to simulate interruption)
sending (3%)...          (cabinet powered back on)
verifying game crc...
running game...
waiting for cabinet...   (several seconds after cabinet powered down)
waiting for cabinet...   (cabinet powered back down)

$ python3 ./netdimm_menu 192.168.1.121 /tmp/romz/
Connecting to net dimm...
Sending menu to net dimm...
Talking to net dimm to wait for ROM selection...
Requested RHYTHM-TENGOKU JAPAN be loaded...
01ba8000 11%
length: 0f000000

$ python3 ./netdimm_menu 192.168.1.121 /tmp/romz/ --persistent
Connecting to net dimm...
Sending menu to net dimm...
Talking to net dimm to wait for ROM selection...
Requested RHYTHM-TENGOKU JAPAN be loaded...
01cd0000 12%             (cabinet powered down & immediately back on to simulate interruption)
Could not send data to NetDimm
Sending game failed, will try again...
Waiting for cabinet to be ready to receive the menu...
Connecting to net dimm...
Sending menu to net dimm...
Talking to net dimm to wait for ROM selection...
Requested RHYTHM-TENGOKU JAPAN be loaded...
01878000 10%  
length: 0f000000
Waiting for cabinet to be power cycled to resend menu... 
Waiting for cabinet to be ready to receive the menu... (cabinet powered down & immediately back on)
Connecting to net dimm...
Sending menu to net dimm...
Talking to net dimm to wait for ROM selection...

# ./netdimm_receive 192.168.1.121 romz.bin
receiving...
ok!
$ xxd romz.bin
00000000: 4e41 4f4d 4920 2020 2020 2020 2020 2020  NAOMI
00000010: 4472 6167 6f6e 4d69 6e64 6564 2020 2020  DragonMinded
00000020: 2020 2020 2020 2020 2020 2020 2020 2020

$ python3 ./host_debug_server --config config.yaml
 * Serving Flask app "netboot.web.app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://0.0.0.0:80/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 302-492-689
...
127.0.0.1 - - [31/Jan/2022 22:29:20] "PUT /cabinets/192.168.1.121 HTTP/1.1" 200 -
127.0.0.1 - - [31/Jan/2022 22:29:20] "GET /config/cabinet/192.168.1.121 HTTP/1.1" 200 -
...
127.0.0.1 - - [31/Jan/2022 22:30:23] "POST /cabinets/192.168.1.121/filename HTTP/1.1" 200 -
Cabinet 192.168.1.121 changed games to /tmp/romz/rhytngk.bin, waiting for power on.
127.0.0.1 - - [31/Jan/2022 22:30:24] "GET /cabinets HTTP/1.1" 200 -
Cabinet 192.168.1.121 sending game /tmp/romz/rhytngk.bin.
Host 192.168.1.121 started sending image.
...
[web console: sending game (27% complete)]
127.0.0.1 - - [31/Jan/2022 22:31:38] "GET /cabinets HTTP/1.1" 200 -      (cabinet powered down & immediately back on to simulate interruption)
Host 192.168.1.121 failed to send image: Could not send data to NetDimm.
Cabinet 192.168.1.121 failed to send game, waiting for power on.
127.0.0.1 - - [31/Jan/2022 22:31:39] "GET /cabinets HTTP/1.1" 200 -
...
[web console: waiting for cabinet]
Cabinet 192.168.1.121 sending game /tmp/romz/rhytngk.bin.
Host 192.168.1.121 started sending image.
[web console: sending game (48% complete)]
127.0.0.1 - - [31/Jan/2022 22:34:47] "GET /cabinets HTTP/1.1" 200 -
...
Host 192.168.1.121 succeeded in sending image.
[web console: verifying game crc]
Cabinet 192.168.1.121 succeeded sending game, rebooting and verifying game CRC.
127.0.0.1 - - [31/Jan/2022 22:34:48] "GET /cabinets HTTP/1.1" 200 -
...
127.0.0.1 - - [31/Jan/2022 22:35:49] "GET /cabinets HTTP/1.1" 200 -
Cabinet 192.168.1.121 passed CRC verification for /tmp/romz/rhytngk.bin, waiting for power off.
127.0.0.1 - - [31/Jan/2022 22:35:53] "GET /cabinets HTTP/1.1" 200 -
...
[web console: running game]

```

A quick spot check indicates all major heavy lifters that would be sending data function fine. 
```
$ grep "from netdimm" . -r 
./scripts/netdimm_menu.py:from netdimm import NetDimm, NetDimmException, Message, send_message, receive_message, write_scratch1_register, MESSAGE_HOST_STDOUT, MESSAGE_HOST_STDERR
./scripts/netdimm_peekpoke.py:from netdimm import NetDimm, PeekPokeTypeEnum
./scripts/netdimm_ensure.py:from netdimm import NetDimmVersionEnum
./scripts/netdimm_info.py:from netdimm import NetDimm, CRCStatusEnum
./scripts/netdimm_receive.py:from netdimm import NetDimm, NetDimmVersionEnum
./scripts/netdimm_send.py:from netdimm import NetDimm, NetDimmVersionEnum
./netboot/web/app.py:from netdimm import NetDimmVersionEnum
./netboot/hostutils.py:from netdimm import NetDimm, NetDimmInfo, NetDimmException, NetDimmVersionEnum
./netboot/cabinet.py:from netdimm import NetDimmInfo, NetDimmException, NetDimmVersionEnum, CRCStatusEnum
...
./netdimm/message.py:from netdimm import NetDimm, PeekPokeTypeEnum
```
